### PR TITLE
chore: solved has_key method error

### DIFF
--- a/language.py
+++ b/language.py
@@ -544,10 +544,10 @@ def defineConstantNoValueLogic(line):
 def typeLogic(line):
     elementfromset = line.split("print ",1)[1].replace('.type()', '')
     for element in elementfromset.split():
-        if variables.has_key(element):
+        if element in variables.keys():
             typeForVariable = variableconstanttypes[element]
             #CHANGES VARIABLE TO NUMBER VALUE FOR MATH
-        elif constants.has_key(element):
+        elif element in constants.keys():
             typeForVariable = variableconstanttypes[element]
             #CHANGES CONSTANT TO NUMBER VALUE FOR MATH
         else:


### PR DESCRIPTION
Note: I don't know if you're still updating this but great work man, I am amazed by this. When I ran it I found a error and solved it.

The has_key method for dict has gone deprecated, but people should be able to run the code, so changed to "in' operator.